### PR TITLE
Handle mismatch in offset during write

### DIFF
--- a/pkg/fs/ftp_test_unix.go
+++ b/pkg/fs/ftp_test_unix.go
@@ -6,6 +6,6 @@ import (
 	"syscall"
 )
 
-const manyLargeFilesCount = 20
+const manyLargeFilesCount = 12
 
 var interruptableSysProcAttr *syscall.SysProcAttr = nil //nolint:gochecknoglobals // OS-specific constant


### PR DESCRIPTION
The offset passed in the write method isn't always aligned with the
offset of the previous write call to the same file descriptor. In
such situations, the current store operation must be closed and allowed
to drain, before a new store operation starts at the new offset.

This commit ensures correct operation of the write offset and separates
the write and read offsets.